### PR TITLE
Fix stdevs error in scale()

### DIFF
--- a/dsmltf.py
+++ b/dsmltf.py
@@ -1142,7 +1142,7 @@ def group_by(grouper, rows, value_transform=None):
 def scale(matrix):
     rows, cols = shape(matrix)
     means = [mean(get_column(matrix, i)) for i in range(cols)]
-    stdevs = [standard_deviatiodsdsn(get_column(matrix, i)) for i in range(cols)]
+    stdevs = [standard_deviation(get_column(matrix, i)) for i in range(cols)]
 
     def res(i, j):
         if stdevs[j] > 0:

--- a/dsmltf.py
+++ b/dsmltf.py
@@ -1142,7 +1142,7 @@ def group_by(grouper, rows, value_transform=None):
 def scale(matrix):
     rows, cols = shape(matrix)
     means = [mean(get_column(matrix, i)) for i in range(cols)]
-    stdevs = [mean(get_column(matrix, i)) for i in range(cols)]
+    stdevs = [standard_deviation(get_column(matrix, i)) for i in range(cols)]
 
     def res(i, j):
         if stdevs[j] > 0:

--- a/dsmltf.py
+++ b/dsmltf.py
@@ -1142,7 +1142,7 @@ def group_by(grouper, rows, value_transform=None):
 def scale(matrix):
     rows, cols = shape(matrix)
     means = [mean(get_column(matrix, i)) for i in range(cols)]
-    stdevs = [standard_deviation(get_column(matrix, i)) for i in range(cols)]
+    stdevs = [standard_deviatiodsdsn(get_column(matrix, i)) for i in range(cols)]
 
     def res(i, j):
         if stdevs[j] > 0:


### PR DESCRIPTION
В функции scale мы заметили, что второй список (stdevs) состоит не из стандартных отклонений, а из средних значений, и поэтому шкалирование данных не работает корректно. В данном случае имеется в виду шкалирование к нормальному распределению `z[i] = (x[i] - means[i]) / stdevs[i]`.